### PR TITLE
Add HMR support to builder-vite

### DIFF
--- a/lib/builder-vite/src/index.ts
+++ b/lib/builder-vite/src/index.ts
@@ -13,10 +13,10 @@ export const getConfig = () => ({});
 
 export const build: ViteBuilder['build'] = async ({ options }) => {};
 
-export const start: ViteBuilder['start'] = async ({ startTime, options, router }) => {
-  const server = await createViteServer(options);
+export const start: ViteBuilder['start'] = async ({ startTime, options, router, server: devServer }) => {
+  const server = await createViteServer(options, devServer);
 
-  router.use(await iframeMiddleware(options));
+  router.use(await iframeMiddleware(options, server));
   router.use(await viteAppMiddleware(options));
 
   router.use((req, res, next) => server.middlewares.handle(req, res, next));

--- a/lib/builder-vite/src/server.ts
+++ b/lib/builder-vite/src/server.ts
@@ -1,16 +1,21 @@
+import { Server } from "http";
 import path from 'path';
 import { createServer, ViteDevServer } from 'vite';
 import vue from '@vitejs/plugin-vue';
-import type { LoadOptions } from '@storybook/core-common';
+import type { CLIOptions, LoadOptions } from "@storybook/core-common";
 import { optimizeDeps } from './utils/optimizeDeps';
 import { mockCoreJs } from './utils/mockCoreJs';
 
-export async function createViteServer({ configDir }: LoadOptions): Promise<ViteDevServer> {
+export async function createViteServer({ configDir, port }: LoadOptions & CLIOptions, devServer: Server): Promise<ViteDevServer> {
   const server = await createServer({
     configFile: false,
     root: path.resolve(configDir, '..'),
     server: {
       middlewareMode: true,
+      hmr: {
+        port,
+        server: devServer,
+      },
     },
     resolve: {
       alias: {

--- a/lib/core-common/src/types.ts
+++ b/lib/core-common/src/types.ts
@@ -169,6 +169,7 @@ export interface Builder<Config, Stats> {
     options: Options;
     startTime: ReturnType<typeof process.hrtime>;
     router: Router;
+    server: Server;
   }) => Promise<void | {
     stats: Stats;
     totalTime: ReturnType<typeof process.hrtime>;

--- a/lib/core-server/src/dev-server.ts
+++ b/lib/core-server/src/dev-server.ts
@@ -59,12 +59,14 @@ export async function storybookDevServer(options: Options) {
         startTime,
         options,
         router,
+        server,
       });
 
   const manager = managerBuilder.start({
     startTime,
     options,
     router,
+    server,
   });
 
   const [previewResult, managerResult] = await Promise.all([


### PR DESCRIPTION
I added HMR support, by passing the http.Server object into the builder, and mounting Vite's HMR Websocket to it.